### PR TITLE
Actualizaciones y mejoras en la extensión VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
 	"version": "0.2.0",
     "configurations": [
         {
-            "name": "Correr Extension",
+            "name": "Ejecutar Extensión",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
             {
                 "type": "latino",
                 "label": "Latino Debug",
-                "program": "C:/Program Files/Latino/bin/latino.exe",
+                "program": "C:/Program Files/Latino/latino.exe",
                 "runtime": "latino.exe",
                 "languages": ["latino", "Latino"]
             }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "main": "./src/extension.js",
     "activationEvents": [
         "onLanguage:latino",
-        "onCommand:latino.correr",
+        "onCommand:latino.ejecutar",
         "onCommand:latino.debug",
         "onCommand:latino.config",
         "workspaceContains:**/.latVSCodeConfig",
@@ -77,15 +77,15 @@
                 "category": "debuging"
             },
             {
-                "command": "latino.correr",
-                "title": "Correr Latino",
+                "command": "latino.ejecutar",
+                "title": "Ejecutar Latino",
                 "category": "debugin",
                 "icon": "$(run)"
             }
         ],
         "keybindings": [
             {
-                "command": "latino.correr",
+                "command": "latino.ejecutar",
                 "key": "ctrl+alt+r",
                 "mac": "cmd+alt+r"
             }
@@ -109,7 +109,7 @@
                 {
                     "id": "terminalTest.terminal-profile",
                     "icon": "terminal",
-                    "title": "Latino Terminal"
+                    "title": "Terminal de Latino"
                 }
             ]
         },
@@ -117,7 +117,7 @@
             "editor/title": [
                 {
                     "when": "resourceLangId == latino",
-                    "command": "latino.correr",
+                    "command": "latino.ejecutar",
                     "group": "navigation"
                 }
             ]
@@ -148,7 +148,7 @@
                 "description": "De sus primeros pasos para configurar Latino en VSCode",
                 "steps": [
                     {
-                        "id": "latinocorrer",
+                        "id": "latinoejecutar",
                         "title": "Latino binario",
                         "description": "Este paso es para configurar la ruta donde se ubica el binario de Latino en su sistema\n[Buscar Binario](command:latino.config)",
                         "media": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,7 +7,11 @@ const provider2 = require("./provider");
 const vscode    = require("vscode");
 const OS        = require("os");
 
-const rutaDefault = (OS.platform() == 'win32') ? "C:/Program Files/Latino/latino.exe" : "/usr/local/bin/latino";
+const NOMBRE_TERMINAL_LATINO = "Terminal de Latino";
+
+const ES_WINDOWS = OS.platform() == 'win32';
+
+const rutaDefault = ES_WINDOWS ? "C:/Program Files/Latino/latino.exe" : "/usr/local/bin/latino";
 let ruta        = rutaDefault.toString();
 let unSave      = false;
 
@@ -117,7 +121,7 @@ function activate(context) {
         provideTerminalProfile(token) {
             return {
                 options: {
-                    name: 'Terminal de Latino',
+                    name: NOMBRE_TERMINAL_LATINO,
                     shellPath: ruta.toString()
                 }
             };
@@ -127,9 +131,27 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('latino.ejecutar', () => {
         if (unSave) {
             vscode.window.showErrorMessage('Error! El archivo no ha sido guardado. Guarde sus cambios antes de ejecutar Latino.');
-        } else {
-            vscode.window.createTerminal('Terminal de Latino', ruta.toString(), '${file}').show();
+            return;
         }
+
+        // Buscamos si ya se ha creado el terminal anteriormente
+        // Si se ha creado ya, lo reutilizamos
+        let terminalLatino = vscode.window.terminals.find(t => t.name === NOMBRE_TERMINAL_LATINO);
+
+        if (!terminalLatino) {
+            terminalLatino = vscode.window.createTerminal({
+                name: NOMBRE_TERMINAL_LATINO,
+            });
+        }
+
+        terminalLatino.show();
+
+        const rutaFichero = vscode.window.activeTextEditor?.document.fileName;
+        let comandoLatino = `"${ruta}" "${rutaFichero}"`;
+
+        if (ES_WINDOWS) comandoLatino = `& ${comandoLatino}`; // Sintaxis de PowerShell
+
+        terminalLatino.sendText(comandoLatino);
     }));
 
     let btnConf         = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);

--- a/src/extension.js
+++ b/src/extension.js
@@ -117,18 +117,18 @@ function activate(context) {
         provideTerminalProfile(token) {
             return {
                 options: {
-                    name: 'Latino Terminal',
+                    name: 'Terminal de Latino',
                     shellPath: ruta.toString()
                 }
             };
         }
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand('latino.correr', () => {
+    context.subscriptions.push(vscode.commands.registerCommand('latino.ejecutar', () => {
         if (unSave) {
-            vscode.window.showErrorMessage('Error! El archivo no a sido guardado...');
+            vscode.window.showErrorMessage('Error! El archivo no ha sido guardado. Guarde sus cambios antes de ejecutar Latino.');
         } else {
-            vscode.window.createTerminal('Latino Terminal', ruta.toString(), '${file}').show();
+            vscode.window.createTerminal('Terminal de Latino', ruta.toString(), '${file}').show();
         }
     }));
 
@@ -140,16 +140,16 @@ function activate(context) {
     // btnBug.text         = "$(debug)";
     // btnBug.command      = 'latino.debug';
 
-    let btnCorrer       = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-    btnCorrer.text      = '$(run) Ejecutar Latino',
-    btnCorrer.command   = 'latino.correr';
+    let btnEjecutar       = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    btnEjecutar.text      = '$(run) Ejecutar Latino',
+    btnEjecutar.command   = 'latino.ejecutar';
 
-    context.subscriptions.push(btnConf/*,btnBug*/, btnCorrer);
+    context.subscriptions.push(btnConf/*,btnBug*/, btnEjecutar);
     context.subscriptions.push(provider1, provider2);
 
     btnConf.show();
     // btnBug.show();
-    btnCorrer.show();
+    btnEjecutar.show();
 }
 
 exports.activate = activate;

--- a/src/extension.js
+++ b/src/extension.js
@@ -7,7 +7,7 @@ const provider2 = require("./provider");
 const vscode    = require("vscode");
 const OS        = require("os");
 
-const rutaDefault = (OS.platform() == 'win32') ? "C:/Program Files/Latino/bin/latino.exe" : "/usr/local/bin/latino";
+const rutaDefault = (OS.platform() == 'win32') ? "C:/Program Files/Latino/latino.exe" : "/usr/local/bin/latino";
 let ruta        = rutaDefault.toString();
 let unSave      = false;
 

--- a/src/provider.js
+++ b/src/provider.js
@@ -10,12 +10,12 @@ const provider1 = vscode.languages.registerCompletionItemProvider('latino', {
         const libCadena             = new vscode.CompletionItem('cadena');
         libCadena.kind              = vscode.CompletionItemKind.Field;
         libCadena.commitCharacters  = ['.'];
-        libCadena.documentation     = new vscode.MarkdownString('Libreria Cadena,contiene las funcionas para manipular las cadenas<string> en Lation');
+        libCadena.documentation     = new vscode.MarkdownString('Libreria cadena, contiene las funcionas para manipular las cadenas<string> en Latino');
 
         const libDic                = new vscode.CompletionItem('dic');
         libDic.kind                 = vscode.CompletionItemKind.Field;
         libDic.commitCharacters     = ['.'];
-        libDic.documentation        = new vscode.MarkdownString("Libreria dic, nos permite manipular los diccionarios en Lation");
+        libDic.documentation        = new vscode.MarkdownString("Libreria dic, nos permite manipular los diccionarios en Latino");
 
         const libLista              = new vscode.CompletionItem('lista');
         libLista.kind               = vscode.CompletionItemKind.Field;


### PR DESCRIPTION
Esta PR tiene como propósito actualizar y mejorar la calidad del proyecto.
Se incluye lo siguiente:

- Renombrado las referencias de "Correr Latino" por "Ejecutar Latino". Esto es porque en algunos países la palabra "Correr" tiene un significado muy distinto.
- Corregida la ruta por defecto en Windows. Se estaba usando la antigua ruta de `C:/Program Files/Latino/bin/latino.exe`, se ha cambiado por `C:/Program Files/Latino/latino.exe`. Dado que es obligatorio que esté incluida la ruta de Latino en el `PATH` de Windows, veo innecesaria la ruta completa.
- Corregidos algunos typos del proyecto.
- Ahora el botón "Ejecutar Latino" spawnea un nuevo terminal incluido de VSCode. El que se usaba anteriormente se cerraba tras unos pocos segundos, haciendo que el usuario se confunda.